### PR TITLE
steam_rsa: add libgcrypt as crypto backend

### DIFF
--- a/steam-mobile/Makefile
+++ b/steam-mobile/Makefile
@@ -2,8 +2,23 @@
 COMPILER = gcc
 PKG_CONFIG ?= pkg-config
 
-LIBPURPLE_CFLAGS += $(shell ${PKG_CONFIG} --cflags glib-2.0 json-glib-1.0 purple nss gnome-keyring-1)
-LIBPURPLE_LIBS += $(shell ${PKG_CONFIG} --libs glib-2.0 json-glib-1.0 purple nss)
+# Global libraries
+LIBPURPLE_CFLAGS += $(shell ${PKG_CONFIG} --cflags glib-2.0 json-glib-1.0 purple gnome-keyring-1)
+LIBPURPLE_LIBS += $(shell ${PKG_CONFIG} --libs glib-2.0 json-glib-1.0 purple)
+
+CFLAGS = ${LIBPURPLE_CFLAGS}
+LIBS = ${LIBPURPLE_LIBS}
+
+# Crypt backend to use
+CRYPT_BACKEND = nss
+
+ifeq (${CRYPT_BACKEND}, nss)
+	CFLAGS += $(shell ${PKG_CONFIG} --cflags nss)
+	LIBS += $(shell ${PKG_CONFIG} --libs nss)
+else ifeq (${CRYPT_BACKEND}, gcrypt)
+	CFLAGS += $(shell libgcrypt-config --cflags) -DUSE_GCRYPT_CRYPTO
+	LIBS += $(shell libgcrypt-config --libs)
+endif
 
 STEAM_SOURCES = \
 	steam_connection.c \
@@ -15,4 +30,4 @@ clean:
 	rm -f libsteam.so
 
 libsteam.so: ${STEAM_SOURCES}
-	${COMPILER} -Wall -I. -g -O2 -fPIC -pipe ${STEAM_SOURCES} -o $@ ${LIBPURPLE_CFLAGS} ${LIBPURPLE_LIBS} -shared
+	${COMPILER} -Wall -I. -g -O2 -fPIC -pipe ${STEAM_SOURCES} -o $@ ${CFLAGS} ${LIBS} -shared

--- a/steam-mobile/steam_rsa.c
+++ b/steam-mobile/steam_rsa.c
@@ -210,22 +210,22 @@ steam_crypt_rsa_enc(const GByteArray *mod, const GByteArray *exp, const GByteArr
   res |= gcry_mpi_scan(&empi, GCRYMPI_FMT_USG, exp->data, exp->len, NULL);
   res |= gcry_mpi_scan(&dmpi, GCRYMPI_FMT_USG, bytes->data, bytes->len, NULL);
 
-  if (G_UNLIKELY(res == 0)) {
+  if (G_LIKELY(res == 0)) {
     res  = gcry_sexp_build(&kata, NULL, "(public-key(rsa(n %m)(e %m)))", mmpi, empi);
     res |= gcry_sexp_build(&data, NULL, "(data(flags pkcs1)(value %m))", dmpi);
 
-    if (G_UNLIKELY(res == 0)) {
+    if (G_LIKELY(res == 0)) {
       res = gcry_pk_encrypt(&cata, data, kata);
 
-      if (G_UNLIKELY(res == 0)) {
+      if (G_LIKELY(res == 0)) {
         gcry_sexp_release(data);
         data = gcry_sexp_find_token(cata, "a", 0);
 
-        if (G_UNLIKELY(data != NULL)) {
+        if (G_LIKELY(data != NULL)) {
           gcry_mpi_release(dmpi);
           dmpi = gcry_sexp_nth_mpi(data, 1, GCRYMPI_FMT_USG);
 
-          if (G_UNLIKELY(dmpi != NULL)) {
+          if (G_LIKELY(dmpi != NULL)) {
             ret = g_byte_array_new();
             g_byte_array_set_size(ret, mod->len);
 


### PR DESCRIPTION
This adds libgcrypt as possible crypto provider to steam_rsa.c and to the Makefile (disabled by default).
The implementation is taken from bitlbee-steam and the credits are given in a comment in steam_rsa.c.
Since bitlebee-steam is under GPL-2 and libgcrypt under LGPL-2.1 this should be fine with the requirements for the pidgin/purple plugins.