### PR TITLE
Synced SPEC with upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ If this is the first time you have downloaded this plugin:
 How to Build RPM package for Fedora/openSUSE/CentOS/RHEL
 =====================
   ```
-  sudo yum -y install rpm-build gcc json-glib-devel libpurple-devel zlib-devel make automake glib2-devel libgnome-keyring-devel
+  sudo yum -y install rpm-build gcc json-glib-devel libpurple-devel zlib-devel make automake glib2-devel libgnome-keyring-devel spectool
   mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
   wget https://github.com/EionRobb/pidgin-opensteamworks/blob/master/steam-mobile/purple-libsteam.spec -O ~/rpmbuild/SPECS/purple-libsteam.spec
-  wget https://github.com/EionRobb/pidgin-opensteamworks/archive/master.tar.gz -O ~/rpmbuild/SOURCES/pidgin-opensteamworks-1.6.1.tar.gz
+  spectool --all --get-files ~/rpmbuild/SPECS/purple-libsteam.spec --directory ~/rpmbuild/SOURCES/
   rpmbuild -ba ~/rpmbuild/SPECS/purple-libsteam.spec
   ```
 

--- a/steam-mobile/purple-libsteam.spec
+++ b/steam-mobile/purple-libsteam.spec
@@ -1,58 +1,68 @@
-%define debug_package %{nil}
-%define plugin_name libsteam
-%define project_name pidgin-opensteamworks
-%define purplelib_name purple-%{plugin_name}
+%global plugin_name libsteam
+%global dir_name steam-mobile
 
-Name: %{project_name}
+%global commit0 72fdb9d0733c63d3a3284e1d289453cc5c5dbcdd
+%global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
+%global date 20151204
+
+Name: purple-%{plugin_name}
 Version: 1.6.1
-Release: 1
+Release: 3.%{date}git%{shortcommit0}%{?dist}
 Summary: Steam plugin for Pidgin/Adium/libpurple
-Group: Applications/Productivity
+
 License: GPLv3
 URL: https://github.com/EionRobb/pidgin-opensteamworks
-Source0: %{project_name}-%{version}.tar.gz
-Requires: pidgin-%{plugin_name}
+Source0: https://github.com/EionRobb/pidgin-opensteamworks/archive/%{commit0}.tar.gz#/pidgin-opensteamworks-%{shortcommit0}.tar.gz
 
-%description
-Meta package.
-
-%package -n %{purplelib_name}
-Summary: Adds support for Steam to Pidgin
-BuildRequires: glib2-devel
-BuildRequires: libpurple-devel
-BuildRequires: json-glib-devel
-BuildRequires: libgnome-keyring-devel
-BuildRequires: nss-devel
+BuildRequires: pkgconfig(glib-2.0)
+BuildRequires: pkgconfig(purple)
+BuildRequires: pkgconfig(json-glib-1.0)
+BuildRequires: pkgconfig(zlib)
+BuildRequires: pkgconfig(nss)
+BuildRequires: pkgconfig(gnome-keyring-1)
 BuildRequires: gcc
-Requires: libpurple
-Requires: json-glib
-Requires: nss
 
 %package -n pidgin-%{plugin_name}
-Summary: Adds pixmaps, icons and smileys for Steam protocol.
-Requires: %{purplelib_name}
+Summary: Adds pixmaps, icons and smileys for Steam protocol
+BuildArch: noarch
+Requires: %{name} = %{version}-%{release}
 Requires: pidgin
 
-%description -n %{purplelib_name}
+%description
 Adds support for Steam to Pidgin, Adium, Finch and other libpurple 
 based messengers.
 
 %description -n pidgin-%{plugin_name}
 Adds pixmaps, icons and smileys for Steam protocol inplemented by steam-mobile.
 
-%prep -n %{purplelib_name}
-%setup -c
+%prep
+%setup -qn pidgin-opensteamworks-%{commit0}
 
-%build -n %{purplelib_name}
-cd %{project_name}-*/steam-mobile/
-make
+# fix W: wrong-file-end-of-line-encoding
+perl -i -pe 's/\r\n/\n/gs' README.md
+
+# generating empty configure script
+cd %{dir_name}
+echo '#!/bin/bash' > configure
+chmod +x configure
+
+%build
+cd %{dir_name}
+%configure
+%make_build
 
 %install
-cd %{project_name}-*/steam-mobile/
+cd %{dir_name}
 %make_install
+chmod 755 %{buildroot}%{_libdir}/purple-2/%{plugin_name}.so
 
-%files -n %{purplelib_name}
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%files
 %{_libdir}/purple-2/%{plugin_name}.so
+%doc README.md
+%license %{dir_name}/LICENSE
 
 %files -n pidgin-%{plugin_name}
 %dir %{_datadir}/pixmaps/pidgin
@@ -64,8 +74,12 @@ cd %{project_name}-*/steam-mobile/
 %dir %{_datadir}/pixmaps/pidgin/protocols/48
 %{_datadir}/pixmaps/pidgin/protocols/48/steam.png
 
-%files
-
 %changelog
+* Fri Dec 04 2015 V1TSK <vitaly@easycoding.org> - 1.6.1-3.20151204git72fdb9d
+- Added license file.
+
+* Sun Nov 29 2015 V1TSK <vitaly@easycoding.org> - 1.6.1-2.20151115git5aef56a
+- Applyed Maxim Orlov's fixes.
+
 * Wed Oct 14 2015 V1TSK <vitaly@easycoding.org> - 1.6.1-1
 - Created first RPM spec for Fedora/openSUSE.


### PR DESCRIPTION
* Synced SPEC with upstream.
* Now using Fedora guidelines.
* Can be built with Fedora COPR and Koji: https://copr.fedoraproject.org/coprs/xvitaly/purple-libsteam/build/144908/
* Debug info will be stripped by RPMBuild in auto-mode.
* Added license and readme (required by Fedora upstream).