### PR TITLE
Added option to display the url of the captcha

### DIFF
--- a/steam-mobile/libsteam.c
+++ b/steam-mobile/libsteam.c
@@ -255,7 +255,11 @@ steam_captcha_image_cb(PurpleUtilFetchUrlData *url_data, gpointer userdata, cons
 	group = purple_request_field_group_new(NULL);
 	purple_request_fields_add_group(fields, group);
 
+#ifdef DISPLAY_CAPTCHA_AS_URL
+	field = purple_request_field_string_new("captcha_image", _("Image url"), g_strdup_printf(STEAM_CAPTCHA_URL, sa->captcha_gid), FALSE);
+#else
 	field = purple_request_field_image_new("captcha_image", _("Image"), response, len);
+#endif
 	purple_request_field_group_add_field(group, field);
 
 	field = purple_request_field_string_new("captcha_response", _("Response"), "", FALSE);
@@ -263,7 +267,11 @@ steam_captcha_image_cb(PurpleUtilFetchUrlData *url_data, gpointer userdata, cons
 
 	purple_request_fields(sa->pc,
 		_("Steam Captcha"), _("Steam Captcha"),
+#ifdef DISPLAY_CAPTCHA_AS_URL
+		_("Paste the url in your browser and input the displayed captcha"),
+#else
 		_("Please verify you are human by typing the following"),
+#endif
 		fields,
 		_("OK"), G_CALLBACK(steam_captcha_ok_cb),
 		_("Logout"), G_CALLBACK(steam_captcha_cancel_cb),
@@ -1271,7 +1279,7 @@ steam_login_cb(SteamAccount *sa, JsonObject *obj, gpointer user_data)
 		} else if (json_object_get_boolean_member(obj, "captcha_needed"))
 		{
 			const gchar *captcha_gid = json_object_get_string_member(obj, "captcha_gid");
-			gchar *captcha_url = g_strdup_printf("https://steamcommunity.com/public/captcha.php?gid=%s", captcha_gid);
+			gchar *captcha_url = g_strdup_printf(STEAM_CAPTCHA_URL, captcha_gid);
 
 			sa->captcha_gid = g_strdup(captcha_gid);
 #if PURPLE_VERSION_CHECK(3, 0, 0)

--- a/steam-mobile/libsteam.h
+++ b/steam-mobile/libsteam.h
@@ -65,6 +65,8 @@
 #define STEAM_PLUGIN_ID "prpl-steam-mobile"
 #define STEAM_PLUGIN_VERSION "1.6.1"
 
+#define STEAM_CAPTCHA_URL "https://steamcommunity.com/public/captcha.php?gid=%s"
+
 typedef struct _SteamAccount SteamAccount;
 typedef struct _SteamBuddy SteamBuddy;
 


### PR DESCRIPTION
Hi, 
I added a preprocessor option so I don't have to manually patch the code for adium.
Adium has a bug displaying images in the purple_request_field, so I just show the url to the captcha.