### PR TITLE
Improve Makefile, fix OS detection in steam_rsa.c, minor compiler fix

### DIFF
--- a/steam-mobile/Makefile
+++ b/steam-mobile/Makefile
@@ -48,4 +48,4 @@ clean:
 	rm -f libsteam.so
 
 libsteam.so: $(STEAM_SOURCES)
-	$(CC) -Wall -I. -fPIC $(CFLAGS) $(STEAM_SOURCES) -o $@ $(LIBPURPLE_CFLAGS) $(LIBPURPLE_LIBS) -shared
+	$(CC) -Wall -I. -fPIC $(CFLAGS) $(STEAM_SOURCES) -o $@ $(LDFLAGS) $(LIBPURPLE_CFLAGS) $(LIBPURPLE_LIBS) -shared

--- a/steam-mobile/Makefile
+++ b/steam-mobile/Makefile
@@ -31,10 +31,13 @@ endif
 
 STEAM_SOURCES = \
 	steam_connection.c \
-	libsteam.c 
+	libsteam.c
 
-.PHONY:	all clean install
+STEAM_OBJS = $(patsubst %.c, %.o, $(STEAM_SOURCES))
+
+
 all: libsteam.so
+
 install:
 	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(PLUGIN_DIR_PURPLE)
 	install -m $(FILE_PERM) libsteam.so $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
@@ -44,8 +47,16 @@ install:
 	install -m $(FILE_PERM) steam22.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/steam.png
 	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48
 	install -m $(FILE_PERM) steam48.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/steam.png
-clean:
-	rm -f libsteam.so
 
-libsteam.so: $(STEAM_SOURCES)
-	$(CC) -Wall -I. -fPIC $(CFLAGS) $(STEAM_SOURCES) -o $@ $(LDFLAGS) $(LIBPURPLE_CFLAGS) $(LIBPURPLE_LIBS) -shared
+clean:
+	rm -f libsteam.so *.o
+
+%.o: %.c
+	$(CC) -Wall -I. -fPIC $(LIBPURPLE_CFLAGS) $(CFLAGS) -c $*.c
+
+libsteam.so: $(STEAM_OBJS)
+	$(CC) -Wall -I. -fPIC $(LIBPURPLE_CFLAGS) $(CFLAGS) $(STEAM_OBJS) -o $@ $(LDFLAGS) $(LIBPURPLE_LIBS) -shared
+
+
+.PHONY:	all clean install
+

--- a/steam-mobile/Makefile
+++ b/steam-mobile/Makefile
@@ -21,6 +21,12 @@ ifeq ($(STEAM_CRYPT_BACKEND), nss)
 else ifeq ($(STEAM_CRYPT_BACKEND), gcrypt)
 	LIBPURPLE_CFLAGS += $(shell libgcrypt-config --cflags) -DUSE_GCRYPT_CRYPTO
 	LIBPURPLE_LIBS += $(shell libgcrypt-config --libs)
+else ifeq ($(STEAM_CRYPT_BACKEND), mbedtls)
+	LIBPURPLE_CFLAGS += -DUSE_MBEDTLS_CRYPTO
+	LIBPURPLE_LIBS += -lmbedtls -lmbedcrypto -lmbedx509
+else ifeq ($(STEAM_CRYPT_BACKEND), openssl)
+	LIBPURPLE_CFLAGS += $(shell ${PKG_CONFIG} --cflags openssl) -DUSE_OPENSSL_CRYPTO
+	LIBPURPLE_LIBS += $(shell ${PKG_CONFIG} --libs openssl)
 endif
 
 STEAM_SOURCES = \

--- a/steam-mobile/steam_rsa.c
+++ b/steam-mobile/steam_rsa.c
@@ -9,7 +9,7 @@ password=<base64rsaencryptedpwd>&username=<steamusername>&emailauth=&captchagid=
 
 */
 
-#if defined USE_OPENSSL_CRYPTO && !(defined __APPLE__ || defined __FreeBSD__ || defined __OpenBSD__)
+#if defined USE_OPENSSL_CRYPTO && !(defined __APPLE__ || defined __unix__)
 #	undef USE_OPENSSL_CRYPTO
 #endif
 

--- a/steam-mobile/steam_rsa.c
+++ b/steam-mobile/steam_rsa.c
@@ -561,7 +561,7 @@ steam_encrypt_password(const gchar *modulus_str, const gchar *exponent_str, cons
 	{
 		unsigned long error_num = ERR_get_error();
 		char *error_str = ERR_error_string(error_num, NULL);
-		purple_debug_error("steam", error_str);
+		purple_debug_error("steam", "%s", error_str);
 		RSA_free(rsa);
 		g_free(encrypted);
 		return NULL;


### PR DESCRIPTION
wrt steam_rsa.c, also see http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system

so this should reliably work for BSDs and linuxes