### PR TITLE
Updated README and SPEC for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ On Fedora you can install [package](https://apps.fedoraproject.org/packages/purp
   sudo dnf install purple-libsteam pidgin-libsteam
 ```
 
+How to install on CentOS/RHEL
+=====================
+On CentOS/RHEL you can install [package](https://apps.fedoraproject.org/packages/purple-libsteam) from Fedora's [EPEL7](http://fedoraproject.org/wiki/EPEL) repository:
+
+```
+  sudo yum install purple-libsteam pidgin-libsteam
+```
+
 How to Build RPM package for Fedora/openSUSE/CentOS/RHEL
 =====================
   ```

--- a/README.md
+++ b/README.md
@@ -24,13 +24,8 @@ How to install on Linux
 
 How to install on Fedora
 =====================
-On Fedora you can use [purple-libsteam](https://copr.fedoraproject.org/coprs/xvitaly/purple-libsteam/) COPR repository. [Later](https://bugzilla.redhat.com/show_bug.cgi?id=1297854), after package review, it will be available from main Fedora repository.
+On Fedora you can install [package](https://apps.fedoraproject.org/packages/purple-libsteam) from Fedora's main repository:
 
-At first time you should add COPR repository and enable it:
-```
-  sudo dnf copr enable xvitaly/purple-libsteam
-```
-Now you can install packages:
 ```
   sudo dnf install purple-libsteam pidgin-libsteam
 ```

--- a/steam-mobile/purple-libsteam.spec
+++ b/steam-mobile/purple-libsteam.spec
@@ -1,13 +1,13 @@
 %global plugin_name libsteam
 %global dir_name steam-mobile
 
-%global commit0 72fdb9d0733c63d3a3284e1d289453cc5c5dbcdd
+%global commit0 0f51fd6219b80aed9c466d1461a076fc2403a1a3
 %global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
-%global date 20151204
+%global date 20160618
 
 Name: purple-%{plugin_name}
 Version: 1.6.1
-Release: 3.%{date}git%{shortcommit0}%{?dist}
+Release: 12.%{date}git%{shortcommit0}%{?dist}
 Summary: Steam plugin for Pidgin/Adium/libpurple
 
 License: GPLv3
@@ -33,7 +33,7 @@ Adds support for Steam to Pidgin, Adium, Finch and other libpurple
 based messengers.
 
 %description -n pidgin-%{plugin_name}
-Adds pixmaps, icons and smileys for Steam protocol inplemented by steam-mobile.
+Adds pixmaps, icons and smileys for Steam protocol implemented by steam-mobile.
 
 %prep
 %setup -qn pidgin-opensteamworks-%{commit0}
@@ -41,14 +41,10 @@ Adds pixmaps, icons and smileys for Steam protocol inplemented by steam-mobile.
 # fix W: wrong-file-end-of-line-encoding
 perl -i -pe 's/\r\n/\n/gs' README.md
 
-# generating empty configure script
-cd %{dir_name}
-echo '#!/bin/bash' > configure
-chmod +x configure
-
 %build
 cd %{dir_name}
-%configure
+export CFLAGS="%{optflags}"
+export LDFLAGS="%{__global_ldflags}"
 %make_build
 
 %install
@@ -56,30 +52,47 @@ cd %{dir_name}
 %make_install
 chmod 755 %{buildroot}%{_libdir}/purple-2/%{plugin_name}.so
 
-%post -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
-
 %files
 %{_libdir}/purple-2/%{plugin_name}.so
 %doc README.md
 %license %{dir_name}/LICENSE
 
 %files -n pidgin-%{plugin_name}
-%dir %{_datadir}/pixmaps/pidgin
-%dir %{_datadir}/pixmaps/pidgin/protocols
-%dir %{_datadir}/pixmaps/pidgin/protocols/16
-%{_datadir}/pixmaps/pidgin/protocols/16/steam.png
-%dir %{_datadir}/pixmaps/pidgin/protocols/22
-%{_datadir}/pixmaps/pidgin/protocols/22/steam.png
-%dir %{_datadir}/pixmaps/pidgin/protocols/48
-%{_datadir}/pixmaps/pidgin/protocols/48/steam.png
+%{_datadir}/pixmaps/pidgin/protocols/*/steam.png
 
 %changelog
-* Fri Dec 04 2015 V1TSK <vitaly@easycoding.org> - 1.6.1-3.20151204git72fdb9d
+* Tue Jun 21 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-12.20160618git0f51fd6
+- Updated to latest Git snapshot. Added missing LDFLAGS to %build.
+
+* Sun Jun 19 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-11.20160618gitcd5a294
+- Updated to latest Git snapshot.
+
+* Sat Jun 18 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-10.20160416gitbf7dd28
+- Updated package description.
+
+* Sun Jun 12 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-9.20160416gitbf7dd28
+- Removed empty configure script.
+
+* Mon May 02 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-8.20160416gitbf7dd28
+- Updated to latest version from Git.
+
+* Fri Mar 04 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-7.20160218git5a5beba
+- Updated to latest version from Git.
+
+* Tue Feb 16 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-6.20160216git9d51f30
+- Updated to latest version from Git.
+
+* Tue Jan 12 2016 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-5.20160108git8646d36
+- Updated to latest version from Git.
+
+* Thu Dec 24 2015 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-4.20151224gitef6215f
+- Updated to latest version.
+
+* Fri Dec 04 2015 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-3.20151204git72fdb9d
 - Added license file.
 
-* Sun Nov 29 2015 V1TSK <vitaly@easycoding.org> - 1.6.1-2.20151115git5aef56a
+* Sun Nov 29 2015 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-2.20151115git5aef56a
 - Applyed Maxim Orlov's fixes.
 
-* Wed Oct 14 2015 V1TSK <vitaly@easycoding.org> - 1.6.1-1
+* Wed Oct 14 2015 Vitaly Zaitsev <vitaly@easycoding.org> - 1.6.1-1
 - Created first RPM spec for Fedora/openSUSE.


### PR DESCRIPTION
* Purple-libsteam package is [now available](https://apps.fedoraproject.org/packages/purple-libsteam) in main Fedora's repository (and EPEL7).
* Updated install HOWTO.
* Synced SPEC with Fedora's upstream.