### PR TITLE
undefined symbol: secret_password_clear

### DIFF
--- a/steam-mobile/libsteam.c
+++ b/steam-mobile/libsteam.c
@@ -178,7 +178,7 @@ steam_account_set_access_token(SteamAccount *sa, const gchar *access_token) {
 											 "domain",		"libpurple",
 											 NULL);
 #else // !USE_GNOME_KEYRING
-			secret_password_clear(my_SSCN, //SECRET_SCHEMA_COMPAT_NETWORK
+			my_secret_password_clear(my_SSCN, //SECRET_SCHEMA_COMPAT_NETWORK
 								  NULL, NULL, NULL,
 								  "user",     sa->account->username,
 								  "server",   "api.steamcommunity.com",


### PR DESCRIPTION
Pidgin refuses to load libsteam.so:
plugins: probing /usr/lib/purple-2/libsteam.so
plugins: /usr/lib/purple-2/libsteam.so is not loadable: undefined symbol: secret_password_clear

Just a typo of 'secret_password_clear' which should be 'my_secret_password_clear'.