### PR TITLE
automatically build and publish Debian packages at https://gitlab.com/nodiscc/pidgin-opensteamworks/-/releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ package-debian-stretch:
     - tags
   script:
     - apt update && apt -y --no-install-recommends install gcc checkinstall libpurple-dev libglib2.0-dev libjson-glib-dev libnss3-dev libsecret-1-dev lintian
-    - cd steam-mobile/ && checkinstall --pkgname=pidgin-opensteamworks --arch=amd64 --pkglicense=GPL-3.0 --pkgsource https://github.com/EionRobb/pidgin-opensteamworks --pkgversion=${CI_COMMIT_TAG}-stretch0 --requires="libpurple0,libglib2.0-0,libjson-glib-1.0-0,libnss3,libsecret-1-0"
+    - cd steam-mobile/ && checkinstall --pkgname=pidgin-opensteamworks --arch=amd64 --pkglicense=GPL-3.0 --pkgsource https://github.com/EionRobb/pidgin-opensteamworks --pkgversion=${CI_COMMIT_TAG}-stretch0 --requires="libpurple0,libglib2.0-0,libjson-glib-1.0-0,libnss3"
     - lintian *.deb || true
     - mv *.deb ../
   artifacts:
@@ -29,7 +29,7 @@ package-debian-buster:
     - tags
   script:
     - apt update && apt -y --no-install-recommends install gcc checkinstall libpurple-dev libglib2.0-dev libjson-glib-dev libnss3-dev libsecret-1-dev lintian
-    - cd steam-mobile/ && checkinstall --pkgname=pidgin-opensteamworks --arch=amd64 --pkglicense=GPL-3.0 --pkgsource https://github.com/EionRobb/pidgin-opensteamworks --pkgversion=${CI_COMMIT_TAG}-buster0 --requires="libpurple0,libglib2.0-0,libjson-glib-1.0-0,libnss3,libsecret-1-0"
+    - cd steam-mobile/ && checkinstall --pkgname=pidgin-opensteamworks --arch=amd64 --pkglicense=GPL-3.0 --pkgsource https://github.com/EionRobb/pidgin-opensteamworks --pkgversion=${CI_COMMIT_TAG}-buster0 --requires="libpurple0,libglib2.0-0,libjson-glib-1.0-0,libnss3"
     - lintian *.deb || true
     - mv *.deb ../
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,60 @@
+stages:
+ - package
+ - release
+ - upload
+
+variables:
+  BUSTER_PACKAGE_FILENAME: "pidgin-opensteamworks_${CI_COMMIT_TAG}-buster0-1_amd64.deb"
+  STRETCH_PACKAGE_FILENAME: "pidgin-opensteamworks_${CI_COMMIT_TAG}-buster0-1_amd64.deb"
+  PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/pidgin-opensteamworks/${CI_COMMIT_TAG}"
+
+package-debian-stretch:
+  image: debian:stretch
+  stage: package
+  only:
+    - tags
+  script:
+    - apt update && apt -y --no-install-recommends install gcc checkinstall libpurple-dev libglib2.0-dev libjson-glib-dev libnss3-dev libsecret-1-dev lintian
+    - cd steam-mobile/ && checkinstall --pkgname=pidgin-opensteamworks --arch=amd64 --pkglicense=GPL-3.0 --pkgsource https://github.com/EionRobb/pidgin-opensteamworks --pkgversion=${CI_COMMIT_TAG}-stretch0 --requires="libpurple0,libglib2.0-0,libjson-glib-1.0-0,libnss3,libsecret-1-0"
+    - lintian *.deb || true
+    - mv *.deb ../
+  artifacts:
+    paths:
+      - ./*.deb
+
+package-debian-buster:
+  image: debian:buster-backports
+  stage: package
+  only:
+    - tags
+  script:
+    - apt update && apt -y --no-install-recommends install gcc checkinstall libpurple-dev libglib2.0-dev libjson-glib-dev libnss3-dev libsecret-1-dev lintian
+    - cd steam-mobile/ && checkinstall --pkgname=pidgin-opensteamworks --arch=amd64 --pkglicense=GPL-3.0 --pkgsource https://github.com/EionRobb/pidgin-opensteamworks --pkgversion=${CI_COMMIT_TAG}-buster0 --requires="libpurple0,libglib2.0-0,libjson-glib-1.0-0,libnss3,libsecret-1-0"
+    - lintian *.deb || true
+    - mv *.deb ../
+  artifacts:
+    paths:
+      - ./*.deb
+
+publish-release:
+  script: echo "publising release $CI_COMMIT_TAG"
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  stage: release
+  release:
+    name: "$CI_COMMIT_TAG"
+    tag_name: "$CI_COMMIT_TAG"
+    ref: "$CI_COMMIT_TAG"
+    description: "Version $CI_COMMIT_TAG\n\nPackages for Debian 10/11 can be found in the [package registry](https://gitlab.com/nodiscc/pidgin-opensteamworks/-/packages?type=&sort=desc&orderBy=version&search[]=)"
+  only:
+    - tags
+
+upload_packages:
+  stage: upload
+  image: curlimages/curl:latest
+  only:
+    - tags
+  script:
+    - |
+      curl --fail -v --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --upload-file ${STRETCH_PACKAGE_FILENAME} ${PACKAGE_REGISTRY_URL}/${STRETCH_PACKAGE_FILENAME}
+    - |
+      curl --fail -v --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --upload-file ${BUSTER_PACKAGE_FILENAME} ${PACKAGE_REGISTRY_URL}/${BUSTER_PACKAGE_FILENAME}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ How to install on Linux
   * Download the latest .so file from the [Downloads Page](https://github.com/EionRobb/pidgin-opensteamworks/releases)
   * Copy the file to ```~/.purple/plugins```
 
+
 How to install on Fedora
 =====================
 On Fedora you can install [package](https://apps.fedoraproject.org/packages/purple-libsteam) from Fedora's main repository:
@@ -38,6 +39,12 @@ On CentOS/RHEL you can install [package](https://apps.fedoraproject.org/packages
   sudo yum install purple-libsteam pidgin-libsteam
 ```
 
+How to install on Ubuntu/Debian
+=====================
+
+Debian packages for Debian 10/11 can be found in the [package registry](https://gitlab.com/nodiscc/pidgin-opensteamworks/-/packages?type=&sort=desc&orderBy=version&search[]=)
+
+
 How to Build RPM package for Fedora/openSUSE/CentOS/RHEL
 =====================
   ```
@@ -48,23 +55,33 @@ How to Build RPM package for Fedora/openSUSE/CentOS/RHEL
   rpmbuild -ba ~/rpmbuild/SPECS/purple-libsteam.spec
   ```
 
-How to Build on Ubuntu
+How to install on Ubuntu/Debian
 =====================
-  * Download the latest tarball from the [Downloads Page](https://github.com/EionRobb/pidgin-opensteamworks/releases)
-  * Make sure you have the development packages/headers for libpurple, glib-2.0, libjson-glib, gnome-keyring, nss
-  * sudo apt-get install libpurple-dev libglib2.0-dev libjson-glib-dev libgnome-keyring-dev libnss3-dev
-  * Run `cd steam-mobile && make && sudo make install`
-  * sudo cp libsteam.so /usr/lib/purple-2/
-
+  * Download the [latest tarball](https://github.com/EionRobb/pidgin-opensteamworks/releases) or `git clone` the repository
+  * Install development packages/headers: `sudo apt install libpurple-dev libglib2.0-dev libjson-glib-dev libnss3-dev libsecret-1-dev`
+  * Build and install the plugin `cd steam-mobile && make && sudo make install`
+  * To build a .deb package: `sudo apt install checkinstall && cd steam-mobile && sudo checkinstall --pkgname=pidgin-opensteamworks --arch=amd64 --pkglicense=GPL-3.0 --pkgsource https://github.com/EionRobb/pidgin-opensteamworks --pkgversion=1.7 --requires="libpurple0,libglib2.0-0,libjson-glib-1.0-0,libgnome-keyring0,libnss3,libsecret-1-0"`
 
 How to Build on Linux
 =====================
-  * Download the latest tarball from the [Downloads Page](https://github.com/EionRobb/pidgin-opensteamworks/releases)
-  * Make sure you have the development packages/headers for libpurple, glib-2.0, libjson-glib, gnome-keyring, nss
+  * Download the [latest tarball](https://github.com/EionRobb/pidgin-opensteamworks/releases) or `git clone` the repository
+  * Make sure you have the development packages/headers for libpurple, glib-2.0, libjson-glib, gnome-keyring, nss, libsecret
   * Run `cd steam-mobile && make && sudo make install`
 
 Changelog
-=========
+========= 
+  * v1.7.1: Add automatic .deb package builds for Debian 9 Stretch and 10 Buster
+  * v1.7:  Add an option to appear as a 'web' user instead of 'mobile' user
+  * v1.7:  Fix to show the name of people who are requesting to add you to their friends list
+  * v1.7:  Add the option to redeem game keys to the account menu
+  * v1.7:  Fixes for displaying the in-game game name
+  * v1.7:  Improvements to steam guard and captcha handling
+  * v1.7:  Ignore invites from groups/clans
+  * v1.7:  Fixes for handling rate-limiting from the server
+  * v1.7:  Fixes a bunch of crashes
+  * v1.7:  Add libgcrypt, mbedtls, openssl as optional crypto backends
+  * v1.7:  Bitlbee and Adium compatibility improvements
+  * v1.7:  Switch to use libsecret instead of gnome-keyring for Telepathy-Haze users
   * v1.6.1 - Fix for repeated offline history
   * v1.6 - Fixes logins and crashes for UTF8 characters in game names, downloads offline history
   * v1.5.1 - Fixes the infinite captcha login loop


### PR DESCRIPTION
- https://gitlab.com/nodiscc/pidgin-opensteamworks/ configured to mirror https://github.com/EionRobb/pidgin-opensteamworks
- let gitlab CI build packages for debian stretch/buster on every git tag and upload them to the package registry (https://gitlab.com/nodiscc/pidgin-opensteamworks/-/packages)
- let gitlab CI create a release at https://gitlab.com/nodiscc/pidgin-opensteamworks/-/releases and link to the packages download page
- run a lintian pass on resulting packages
- use debian buster-backports image as checkinstall is only available in buster-backports
- update documentation
- ref. https://docs.gitlab.com/ce/ci/yaml/README.html

![01](https://user-images.githubusercontent.com/3950390/122609543-b0229080-d06d-11eb-955d-6a1f99d35421.png)

    ---->

![02](https://user-images.githubusercontent.com/3950390/122609550-b3b61780-d06d-11eb-8b5b-1de13de88c84.png)

    ---->

![03](https://user-images.githubusercontent.com/3950390/122609559-b6187180-d06d-11eb-84e2-3f74a311e4b6.png)

    ---->

![04](https://user-images.githubusercontent.com/3950390/122609563-b87acb80-d06d-11eb-9b6d-aa0b69f1c4cf.png)

    ---->

![05](https://user-images.githubusercontent.com/3950390/122609569-bb75bc00-d06d-11eb-951b-493ec9a78c7e.png)
